### PR TITLE
Add promise-polyfill to dependencies list for npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express": "^4.15.2",
     "firebase": "^4.0.0",
     "lodash": "^4.17.4",
+    "promise-polyfill": "^6.0.2",
     "rxjs": "^5.1.0",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.8.4"


### PR DESCRIPTION
While the 'yarn' command seems to install promise-polyfill, 'npm install' doesn't.  Although yarn is preferred for this course, it fails to find the Visual C++ compiler on Windows (using VS 2017 Community Edition on Windows 10), preventing node-sass from building properly.  Thus it may be advised to explicitly include the promise-polyfill dependency to facilitate those on Windows who may be restricted to using npm install.